### PR TITLE
Re-add legacy bluetooth property

### DIFF
--- a/common-prop.mk
+++ b/common-prop.mk
@@ -118,6 +118,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 # BT address
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.vendor.bt.bdaddr_path=/data/vendor/bluetooth/bluetooth_bdaddr
+    ro.bt.bdaddr_path=/data/vendor/bluetooth/bluetooth_bdaddr
 
 # System prop for NFC DT
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
Needed for legacy devices.
See https://github.com/sonyxperiadev/bug_tracker/issues/218